### PR TITLE
Fix TimeDate TimeDate subtration

### DIFF
--- a/src/arith.jl
+++ b/src/arith.jl
@@ -2,12 +2,9 @@
 (+)(tdz::TimeDateZone) = tdz
 
 function (-)(td1::TimeDate, td2::TimeDate)
-    dtm1 = DateTime(td1)
-    dtm2 = DateTime(td2)
-    dtm0 = canonical(Microsecond(td1) - Microsecond(td2) + Nanosecond(td1) - Nanosecond(td2))
-    dtm = dtm1 - dtm2
-    dtm += dtm0
-    return sum(fldmod(dtm))
+    Δns=at_time(td1) - at_time(td2)
+    Δday=on_date(td1) - on_date(td2)
+    return Nanosecond(Δday)+Δns
 end
 
 (-)(td::TimeDate, dt::DateTime) = td - TimeDate(dt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,3 +136,13 @@ tdz_implicit_day_hour = TimeDateZone(spring, warsaw) + Day(1) + Hour(24)
 @test TimeDate(1900)+Δms == TimeDate(str2)
 @test TimeDate(1900)-(-Δms) == TimeDate(str2)
 @test TimeDate(str2)-Nanosecond(Δms) == TimeDate(1900)
+
+Δtd = td3 - TimeDate(1900)
+@test canonical(Δtd) == Nanosecond(3729608940042968750) == mapfoldl(Nanosecond,+,canonical(Δtd))
+@test dt2 - dt1 == td2 - td1
+let
+    td1 = TimeDate(2020,2,28,23,59,59,999,999,990)
+    td2 = TimeDate(2020,3,1,0,0,0,0,0,10)
+    @test td2 - td1 == Day(1)+Nanosecond(20)
+    @test td1 - td2 == Day(-1)+Nanosecond(-20) == Nanosecond(-86400000000020)
+end


### PR DESCRIPTION
Fix `TimeDate` by `TimeDate` subtraction.  Returns the period in `Nanosecond`.  Will overflow at a period of approximately 292 years.