### PR TITLE
Sped up TimeDate, TimeDateZone comparison operators

### DIFF
--- a/src/TimeDate.jl
+++ b/src/TimeDate.jl
@@ -41,8 +41,8 @@ end
 @inline Time(x::TimeDate) = at_time(x)
 @inline Date(x::TimeDate) = on_date(x)
 
-@inline fastpart(x::Time) = Nanosecond(x) + Microsecond(x)
-@inline slowpart(x::Time) = x - (Nanosecond(x) + Microsecond(x))
+@inline fastpart(x::Time) = Nanosecond(rem(x.instant.value, MICROSECONDS_PER_SECOND))
+@inline slowpart(x::Time) = x - fastpart(x)
 
 @inline fastpart(x::Date) = Nanosecond(0)
 @inline slowpart(x::Date) = Millisecond(0)

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -1,45 +1,30 @@
-function (==)(x::TimeDate, y::TimeDate)
-     Date(x) === Date(y) && Time(x) === Time(y)
-end
-function (!=)(x::TimeDate, y::TimeDate)
-     Date(x) !== Date(y) || (Date(x) == Date(y) && Time(x) != Time(y))
-end
-function (<)(x::TimeDate, y::TimeDate)
-    dtx = DateTime(x)
-    dty = DateTime(y)
-    (dtx < dty) || ((dtx === dty) && (Time(x) < Time(y)))
-end
-function (>)(x::TimeDate, y::TimeDate)
-    dtx = DateTime(x)
-    dty = DateTime(y)
-    (dtx > dty) || ((dtx === dty) && (Time(x) > Time(y)))
-end
-function (<=)(x::TimeDate, y::TimeDate)
-    dtx = DateTime(x)
-    dty = DateTime(y)
-    (dtx < dty) || ((dtx === dty) && (Time(x) <= Time(y)))
-end
-function (>=)(x::TimeDate, y::TimeDate)
-    dtx = DateTime(x)
-    dty = DateTime(y)
-    (dtx > dty) || ((dtx === dty) && (Time(x) >= Time(y)))
+function isless(x::TimeDate, y::TimeDate)
+    x.ondate < y.ondate || (x.ondate == y.ondate && x.attime < y.attime)
 end
 
 function isequal(x::TimeDate, y::TimeDate)
-    xx = Microsecond(x) + Nanosecond(x)
-    yy = Microsecond(y) + Nanosecond(y)
-    zx = DateTime(x)
-    zy = DateTime(y)
-    isequal(zx, zy) && isequal(xx, yy)
+    x.ondate == y.ondate && x.attime == y.attime
 end
 
-function isless(x::TimeDate, y::TimeDate)
-    xx = Microsecond(x) + Nanosecond(x)
-    yy = Microsecond(y) + Nanosecond(y)
-    zx = DateTime(x)
-    zy = DateTime(y)
-    isless(zx, zy) || (isequal(zx,zy) && isless(xx, yy))
+function isless(x::TimeDateZone, y::TimeDateZone)
+    zx = ZonedDateTime(x)
+    zy = ZonedDateTime(y)
+    isless(zx,zy) && return true 
+    !isequal(zx,zy) && return false
+    xx = Nanosecond(Microsecond(x)) + Nanosecond(x)
+    yy = Nanosecond(Microsecond(y)) + Nanosecond(y)
+    return isless(xx, yy)
 end
+
+function isequal(x::TimeDateZone, y::TimeDateZone)
+    zx = ZonedDateTime(x)
+    zy = ZonedDateTime(y)
+    !isequal(zx,zy) && return false 
+    xx = Nanosecond(Microsecond(x)) + Nanosecond(x)
+    yy = Nanosecond(Microsecond(y)) + Nanosecond(y)
+    return isequal(xx, yy)
+end
+
 
 isequal(x::TimeDate, y::DateTime) = isequal(x, TimeDate(y))
 isequal(x::DateTime, y::TimeDate) = isequal(TimeDate(x), y)
@@ -62,22 +47,12 @@ isless(x::DateTime, y::TimeDate) = isless(TimeDate(x), y)
 (==)(x::DateTime, y::TimeDate) = (==)(TimeDate(x), y)
 (!=)(x::DateTime, y::TimeDate) = (!=)(TimeDate(x), y)
 
-
-function isequal(x::TimeDateZone, y::TimeDateZone)
-    xx = Microsecond(x) + Nanosecond(x)
-    yy = Microsecond(y) + Nanosecond(y)
-    zx = ZonedDateTime(x)
-    zy = ZonedDateTime(y)
-    isequal(zx, zy) && isequal(xx, yy)
-end
-
-function isless(x::TimeDateZone, y::TimeDateZone)
-    xx = Microsecond(x) + Nanosecond(x)
-    yy = Microsecond(y) + Nanosecond(y)
-    zx = ZonedDateTime(x)
-    zy = ZonedDateTime(y)
-    isless(zx, zy) || (isequal(zx,zy) && isless(xx, yy))
-end
+(<)(x::TimeDate, y::TimeDate) = isless(x,y)
+(>)(x::TimeDate, y::TimeDate) = isless(y,x)
+(<=)(x::TimeDate, y::TimeDate) = isless(x,y) || isequal(x,y)
+(>=)(x::TimeDate, y::TimeDate) = isless(y,x) || isequal(x,y)
+(==)(x::TimeDate, y::TimeDate) = isequal(x,y)
+(!=)(x::TimeDate, y::TimeDate) = !isequal(x,y)
 
 
  (<)(x::TimeDateZone, y::TimeDateZone) = isless(x,y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
 str1 = "2011-05-08T11:15:00"
 str2 = "2015-08-17T21:08:11.125"
 str3 = "2018-03-09T18:29:00.04296875"
+str4 = "2018-03-09T18:29:00.04296999"
 
 dt1 = DateTime(str1)
 dt2 = DateTime(str2)
@@ -11,6 +12,8 @@ dt2 = DateTime(str2)
 td1 = TimeDate(str1)
 td2 = TimeDate(str2)
 td3 = TimeDate(str3)
+td3_copy = TimeDate(str3)
+td4 = TimeDate(str4)
 
 dtz1 = ZonedDateTime(dt1, tz"UTC")
 dtz2 = ZonedDateTime(dt1, tz"America/New_York")
@@ -36,6 +39,18 @@ tdz2 = TimeDateZone(td1, tz"America/New_York")
 @test yearmonthday(td1) == yearmonthday(dt1)
 @test lastdayofmonth(td1) == lastdayofmonth(dt1)
 
+@test td1 < td2
+@test td2 > td1
+@test td3 == td3_copy
+@test td3 <= td4
+@test td1 != td3
+@test td2 >= td1 
+@test td2 >= td2
+@test td1 <= td2 
+@test td1 <= td1
+
+
+
 str2000ms    = "2000-01-01T00:00:00.123"
 str2000ms_ut = string(str2000ms, "+00:00")
 str2000ms_ny = string(str2000ms, "-05:00")
@@ -53,13 +68,23 @@ tdz2000_ny = TimeDateZone(str2000ns_ny)
 @test  zdt2000_ut == ZonedDateTime(tdz2000_ut)
 @test  zdt2000_ny == ZonedDateTime(tdz2000_ny)
 
+tdz2000_ut_gt = tdz2000_ut + Nanosecond(1)
+tdz2000_ut_copy = deepcopy(tdz2000_ut)
+
+@test tdz2000_ut < tdz2000_ut_gt 
+@test tdz2000_ut <= tdz2000_ut_gt
+@test tdz2000_ut <= tdz2000_ut
+@test tdz2000_ut_gt > tdz2000_ut
+@test tdz2000_ut_gt >= tdz2000_ut
+@test tdz2000_ut_gt >= tdz2000_ut_gt
+@test tdz2000_ut_gt != tdz2000_ut
+@test tdz2000_ut_copy == tdz2000_ut
 
 zdt = ZonedDateTime(DateTime("2011-05-08T12:11:15.050"), tz"Australia/Sydney")
 tdz = TimeDateZone(zdt)
 tdz += Microsecond(11)
 
 # recasted tests from TimeZones.jl/test/
-
 
 warsaw = tz"Europe/Warsaw"
 


### PR DESCRIPTION
This PR speeds up the comparison operators for `TimeDate`, `TimeDateZone` and fixes `isless` erroring out when comparing `TimeDateZone`s. Running the following script on my home laptop:

```
using Dates, CompoundPeriods, TimeZones, TimesDates

str1 = "2011-05-08T11:15:00"
str2 = "2015-08-17T21:08:11.125"
str3 = "2018-03-09T18:29:00.04296875"
str4 = "2018-03-09T18:29:00.04296999"

td1 = TimeDate(str1)
td2 = TimeDate(str2)
td3 = TimeDate(str3)
td3_copy = TimeDate(str3)
td4 = TimeDate(str4)

str2000ms    = "2000-01-01T00:00:00.123"
str2000ms_ut = string(str2000ms, "+00:00")

str2000ns    = "2000-01-01T00:00:00.123456789"
str2000ns_ut = string(str2000ns, "+00:00")

tdz2000_ut = TimeDateZone(str2000ns_ut)
tdz2000_ut_gt = tdz2000_ut + Nanosecond(1)
tdz2000_ut_copy = deepcopy(tdz2000_ut)

@btime td1 < td2
@btime td3 == td4

@btime tdz2000_ut < tdz2000_ut_gt 
@btime tdz2000_ut_copy == tdz2000_ut
```

yields the following performance improvements

On `master`:
<img width="437" alt="Screen Shot 2019-12-06 at 4 26 02 PM" src="https://user-images.githubusercontent.com/771028/70365425-2d98fe00-1846-11ea-92ed-036df8b667a6.png">

This PR:
<img width="382" alt="Screen Shot 2019-12-06 at 4 24 40 PM" src="https://user-images.githubusercontent.com/771028/70365432-34277580-1846-11ea-9995-6698d5bf9a1d.png">
