### PR TITLE
Proposal: TimesDates.timedate2unix and TimesDates.unix2timedate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 CompoundPeriods = "a216cea6-0a8c-5945-ab87-5ade47210022"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]
-
 [compat]
 CompoundPeriods = "0"
 TimeZones = "1"

--- a/src/TimesDates.jl
+++ b/src/TimesDates.jl
@@ -64,4 +64,26 @@ include("compare.jl")
 include("showstring.jl")
 include("passthru.jl")
 
+"""
+Same as `Dates.datetime2unix`, only with nanosecond granularity. Returns an Int instead of Float.
+"""
+function timedate2unix(x::TimeDate)
+    millis = round(Int64, Dates.datetime2unix(DateTime(x)) * MILLISECONDS_PER_SECOND)
+    millis * NANOSECONDS_PER_MILLISECOND +
+        Dates.value(Microsecond(x)) * NANOSECONDS_PER_MICROSECOND +
+        Dates.value(Nanosecond(x))
+end
+
+"""
+Similar to `Dates.unix2datetime`. Works with the result of `timedate2unix`.
+"""
+function unix2timedate(v :: Int)
+    nanos = v % NANOSECONDS_PER_MICROSECOND
+    micros = div(v % NANOSECONDS_PER_MILLISECOND - nanos, MICROSECONDS_PER_MILLISECOND)
+    epoch_millis = div(v, NANOSECONDS_PER_MILLISECOND)
+    dt = Dates.unix2datetime(epoch_millis / 1000)
+    TimeDate(dt) + Microsecond(micros) + Nanosecond(nanos)
+end
+
+
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+CompoundPeriods = "a216cea6-0a8c-5945-ab87-5ade47210022"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,3 +171,10 @@ let
     @test td2 - td1 == Day(1)+Nanosecond(20)
     @test td1 - td2 == Day(-1)+Nanosecond(-20) == Nanosecond(-86400000000020)
 end
+
+@testset "unix epoch" begin
+    td = TimeDate(2020,2,28,10,11,15,321,543,12)
+    epoch_nanos = TimesDates.timedate2unix(td)
+    @test epoch_nanos == 1582884675321543012
+    @test td == TimesDates.unix2timedate(epoch_nanos)
+end


### PR DESCRIPTION
This seems like a generically useful function which I find a pain to reimplement over and over. The functions do not maintain correspondence with `Dates.unix2datetime` and `Dates.datetime2unix` which return a float with the number of milliseconds after the decimal point. Given that the naming is different, I think the right decision is to use integers. It's clearer and avoids precision loss.

What do you think?