### PR TITLE
fix TimeDate(y, m, d, ...) month spillover

### DIFF
--- a/src/TimeDate.jl
+++ b/src/TimeDate.jl
@@ -88,12 +88,12 @@ function TimeDate(y::Int64, m::Int64=1, d::Int64=1,
   h += fl
   fl, h = fldmod(h, HOURS_PER_DAY)
   d += fl
-  my, m = fldmod(m, MONTHS_PER_YEAR)
+  my, m = fldmod(m, MONTHS_PER_YEAR+1)
   y += my
-    
-  dt = Date(y, m, d)
+
+  dt = Date(y, max(1, m), d)
   tm = Time(h, mi, s, ms, us, ns)
-  td = TimeDate(dt, tm) 
+  td = TimeDate(dt, tm)
   return td
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,3 +171,9 @@ let
     @test td2 - td1 == Day(1)+Nanosecond(20)
     @test td1 - td2 == Day(-1)+Nanosecond(-20) == Nanosecond(-86400000000020)
 end
+
+@test TimeDate(2020, 1, 1) == TimeDate(Date(2020, 1, 1))
+@test TimeDate(2020, 12, 1) == TimeDate(Date(2020, 12, 1))
+@test TimeDate(2020, 13, 1) == TimeDate(Date(2021, 1, 1))
+@test TimeDate(2020, 13, 1, 24) == TimeDate(Date(2021, 1, 2))
+@test TimeDate(2020, 13, 1, 25) == TimeDate(Date(2021, 1, 2), Time(1))


### PR DESCRIPTION
Just ran into a bug when doing `TimeDate(2020, 12, 1)` because of clever `fldmod` usage to spill over excess units into the higher order "field". The months are improperly spilled over to years.

Currently the tests break on Julia 1.6 because of https://github.com/JeffreySarnoff/CompoundPeriods.jl/issues/3